### PR TITLE
Removing MutationObservers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bondo
 
-This is just a little glue between [Custom Elements](https://w3c.github.io/webcomponents/spec/custom/) and [Virtual-DOM](https://github.com/Matt-Esch/virtual-dom) using [Mutation Observers](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) to trigger DOM patches.
+This is just a little glue between [Custom Elements](https://w3c.github.io/webcomponents/spec/custom/) and [Virtual-DOM](https://github.com/Matt-Esch/virtual-dom).
 
 ## Usage
 
@@ -26,7 +26,7 @@ Then use it as a standard Custom Element.
 
 Whenever the element's attributes change the view function gets called again and the existing innerDom gets patched with changes.
 
-The first argument passed to the view function is the actual DOM element so it's attributes can be used when rendering the VDOM. The element's attributes will be observed and any changes will automatically trigger an update of the VDOM.
+The first argument passed to the view function is the actual DOM element so it's attributes can be used when rendering the VDOM. Whenever the element's attributes change the VDOM will be rendered again and the contents of the element will be patched.
 
 Subsequent arguments to the view function are any arguments passed to bondo() following the view function. These are optional. 
 

--- a/bondo.js
+++ b/bondo.js
@@ -1,5 +1,5 @@
 'use strict';
-
+console.log("hello 2 world");
 // polyfills
 require('document-register-element');
 require('mutationobserver-shim');

--- a/bondo.js
+++ b/bondo.js
@@ -1,8 +1,8 @@
 'use strict';
 console.log("hello 2 world");
+
 // polyfills
 require('document-register-element');
-require('mutationobserver-shim');
 
 let h = bondo.h = require('virtual-dom/h');
 let diff = require('virtual-dom/diff');
@@ -39,9 +39,11 @@ function bondo(name, view, ...others) {
           this._root = createElement(this._tree);
           this.appendChild(this._root);
           
-          // update the vtree whenever the attributes change
-          this._observer = new MutationObserver(() => this._update());
-          this._observer.observe(this, { attributes: true });
+        }
+      },
+      attributeChangedCallback: {
+        value: function () {
+          this._update();
         }
       },
       detachedCallback: {

--- a/dist.js
+++ b/dist.js
@@ -1,0 +1,60 @@
+'use strict';
+console.log("hello 2 world");
+
+// polyfills
+require('document-register-element');
+
+var h = bondo.h = require('virtual-dom/h');
+var diff = require('virtual-dom/diff');
+var patch = require('virtual-dom/patch');
+var createElement = require('virtual-dom/create-element');
+
+// start dom-delegator to look for ev-* attributes
+var delegator = require("dom-delegator");
+var d = delegator();
+
+module.exports = bondo;
+
+function bondo(name, view) {
+  for (var _len = arguments.length, others = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
+    others[_key - 2] = arguments[_key];
+  }
+
+  var constructor = document.registerElement(name, {
+    prototype: Object.create(HTMLElement.prototype, {
+      _update: {
+        value: function value() {
+          var newTree = view.apply(undefined, [this].concat(others));
+          patch(this._root, diff(this._tree, newTree));
+          this._tree = newTree;
+        }
+      },
+      createdCallback: {
+        value: function value() {
+
+          // empty the element
+          while (this.firstChild) {
+            this.removeChild(this.firstChild);
+          }
+
+          // render the view for the first time and put it in the custom element
+          this._tree = view.apply(undefined, [this].concat(others));
+          this._root = createElement(this._tree);
+          this.appendChild(this._root);
+        }
+      },
+      attributeChangedCallback: {
+        value: function value() {
+          this._update();
+        }
+      },
+      detachedCallback: {
+        value: function value() {
+          this._observer.disconnect();
+        }
+      }
+    })
+  });
+
+  return constructor;
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "tape test.js",
     "start": "cd test; wzrd test.js -- -t babelify -d",
-    "prepublish": "babel bondo.es6 -o index.js"
+    "prepublish": "babel bondo.js -o index.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
   "name": "bondo",
   "version": "2.0.2",
   "description": "A nano framework for Web Components utilizing Virtual-DOM and MutationObservers",
-  "main": "index.js",
+  "main": "bondo.js",
   "scripts": {
     "test": "tape test.js",
     "start": "cd test; wzrd test.js -- -t babelify -d",
-    "prepublish": "babel bondo.js -o index.js"
+    "prepublish": "babel bondo.js -o dist.js"
   },
   "repository": {
     "type": "git",
@@ -16,7 +16,6 @@
     "components",
     "Custom Elements",
     "DOM",
-    "MutationObserver",
     "Observer",
     "virtual-dom",
     "vdom",
@@ -31,7 +30,6 @@
   "dependencies": {
     "document-register-element": "^0.4.1",
     "dom-delegator": "^13.1.0",
-    "mutationobserver-shim": "^0.3.1",
     "virtual-dom": "^2.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bondo",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A nano framework for Web Components utilizing Virtual-DOM and MutationObservers",
   "main": "bondo.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
-const bondo = require('../index.js');
+const bondo = require('../bondo.js');
 const h = bondo.h;
 
 const test = require('tape');


### PR DESCRIPTION
Turns out that CustomElements have an attributeChangeCallback that does the same thing as MutationObservers for my purposes. Silly oversight that. 

Also, was having some trouble with the transpiled index.js file, so I renamed it to dist.js and made the es6 file my package.main. This means that dependents should really take it upon themselves to babelify. 